### PR TITLE
Fix bash command line in build script

### DIFF
--- a/build_and_run_umt.sh
+++ b/build_and_run_umt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/bash -xe
 # This script will compile a basic Release build of UMT.  Additional CMake options can be added to the command line args of this
 # script, and they will be picked up and added to the UMT CMake command at the bottom of this script.
 # For a list of supported CMake options, run 'ccmake /path/to/umt/src'.


### PR DESCRIPTION
On some systems, /bin/sh points to dash, which does not support some bash constructs, like `${BASH_SOURCE[0]}`.  Change #! line to /bin/bash instead.

Add -e option to stop upon first command that fails.